### PR TITLE
ci: Push images to opensource ECR

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -29,3 +29,12 @@ jobs:
 
       - name: Build and push image
         run: make build-push-multiplatform
+
+      - name: Login to Open Source ECR
+        run: make login-opensource
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OPENSOURCE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OPENSOURCE_SECRET_ACCESS_KEY }}
+
+      - name: Build and push image to Open Source ECR
+        run: make build-push-multiplatform-opensource

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -39,3 +39,12 @@ jobs:
 
       - name: Push kubernetes-setup image
         run: make build-push-multiplatform BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+
+      - name: Login to Open Source ECR
+        run: make login-opensource
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OPENSOURCE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OPENSOURCE_SECRET_ACCESS_KEY }}
+
+      - name: Build and push image to Open Source ECR
+        run: make build-push-multiplatform-opensource BUILD_TAG=${{ steps.extract_tag.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BUILD_TAG ?= latest
 IMAGE_NAME = kubernetes-setup
-ECR_URL = public.ecr.aws/sumologic
+ECR_URL = public.ecr.aws/u5z5f8z6
 REPO_URL = $(ECR_URL)/$(IMAGE_NAME)
+OPENSOURCE_ECR_URL = public.ecr.aws/a4t4y2n3
+OPENSOURCE_REPO_URL = $(OPENSOURCE_ECR_URL)/$(IMAGE_NAME)
 
 build:
 	DOCKER_BUILDKIT=1 docker build \
@@ -26,3 +28,16 @@ build-push-multiplatform:
 		--build-arg BUILD_TAG=$(BUILD_TAG) \
 		--tag $(REPO_URL):$(BUILD_TAG) \
 		.
+
+login-opensource:
+	aws ecr-public get-login-password --region us-east-1 \
+	| docker login --username AWS --password-stdin $(OPENSOURCE_ECR_URL)
+
+build-push-multiplatform-opensource:
+	docker buildx build \
+		--push \
+		--platform linux/amd64,linux/arm/v7,linux/arm64 \
+		--build-arg BUILD_TAG=$(BUILD_TAG) \
+		--tag $(OPENSOURCE_REPO_URL):$(BUILD_TAG) \
+		.
+


### PR DESCRIPTION
A separate AWS account has been created for Sumo Logic's opensource artifacts.
During the transition period, we want to push images to both registries - the original and the opensource one.