### PR TITLE
ci(dependabot): Simplify update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"


### PR DESCRIPTION
Due to a recent change in how Dependabot schedules updates,
the `time` and `timezone` entries are no longer needed.
See https://github.blog/changelog/2021-06-16-dependabot-now-schedules-version-updates-uniformly/

See also similar PR: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/pull/250