### PR TITLE
Fix deprecations in github actions

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
 
       - name: Print tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"


### PR DESCRIPTION
remove set-output based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/