### PR TITLE
chore: prepare release 3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.15.1] - 2024-07-01
+
+This version builds new docker images to include Terraform provider for Sumo Logic [v2.31.0][provider_v2.31.0]
+
+[v3.15.1]: https://github.com/SumoLogic/sumologic-kubernetes-setup/releases/v3.15.1
+[provider_v2.31.0]: https://github.com/SumoLogic/terraform-provider-sumologic/releases/tag/v2.31.0
+
 ## [v3.15.0] - 2024-06-24
 
 - build(deps): bump alpine from 3.19.1 to 3.20.1 [#103], [#108]


### PR DESCRIPTION
## [v3.15.1] - 2024-07-01

This version builds new docker images to include Terraform provider for Sumo Logic [v2.31.0][provider_v2.31.0]

[v3.15.1]: https://github.com/SumoLogic/sumologic-kubernetes-setup/releases/v3.15.1
[provider_v2.31.0]: https://github.com/SumoLogic/terraform-provider-sumologic/releases/tag/v2.31.0