### PR TITLE
chore: Bump terraform from v1.9.7 to v1.10.5

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   setup-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   setup-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build setup image

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   setup-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.9.7 as terraform
+FROM hashicorp/terraform:1.10.5 as terraform
 
 FROM alpine:3.21.3
 

--- a/Dockerfile-ubi
+++ b/Dockerfile-ubi
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:1.9.7 as terraform
+FROM hashicorp/terraform:1.10.5 as terraform
 
 FROM registry.access.redhat.com/ubi8/ubi:8.10
 


### PR DESCRIPTION
Bump terraform from v1.9.7 to [v1.10.5](https://github.com/hashicorp/terraform/releases/tag/v1.10.5)

This addresses [CVE-2025-0377](https://github.com/advisories/GHSA-wpfp-cm49-9m9q) 

Also, bumps our runners to use ubuntu-24.04 